### PR TITLE
Add Chrome OS Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 title: Journey to the Center of Hawkthorne
 ---
 <p>This 2d platformer is based on Community's <a href="http://en.wikipedia.org/wiki/Digital_Estate_Planning">Digital Estate Planning</a>
-episode. It's built using the <a href="https://love2d.org/">love</a> game engine. Please
+episode. It's built using the <a href="https://love2d.org/">LÖVE</a> game engine. Please
 report any issues or bugs you have with the game!</p>
 
 <h2>Development</h2>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@ report any issues or bugs you have with the game!</p>
 <li><a href="http://files.projecthawkthorne.com/releases/latest/hawkthorne-win-x86.zip">Windows 32bit</a></li>
 <li><a href="http://files.projecthawkthorne.com/releases/latest/hawkthorne-win-x64.zip">Windows 64bit</a></li>
 <li><a href="http://files.projecthawkthorne.com/releases/latest/hawkthorne-osx.zip">OS X</a></li>
+<li><a href="https://chrome.google.com/webstore/detail/journey-to-the-center-of/mjkgnligfpbegfahphphpgkbppbjcghm">Chrome OS</a></li>
 </ul>
 
 <p>Linux users: Install <a href="https://love2d.org/">LÖVE</a>. You'll need at


### PR DESCRIPTION
I've created a packaged version of Journey to the Center of Hawkthorne for Chrome OS. It is available here: https://chrome.google.com/webstore/detail/journey-to-the-center-of/mjkgnligfpbegfahphphpgkbppbjcghm

I updated the page to list it for Chrome OS users.
